### PR TITLE
fix: improve the function parsing of non-schema-function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .gradle
 /local.properties
 .idea/
+.kotlin/
+.vscode/
 .DS_Store
 /build
 /captures

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ adb shell aflags list | grep "enable_app_functions_schema_parser"
 
 If this flag is not set to enabled, you will need to modify the `USE_CONTENT_PROVIDER` variable to true in the following file: `agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt`.
 
+> [!NOTE]
+>
+> Using `USE_CONTENT_PROVIDER=true` serves as a workaround for devices that don't support dynamic parsing. However, this method may return incomplete data, such as functions with missing descriptions. This fallback is intended to ensure basic functionality and reflects a limitation of the `androidx.appfunctions` library.
+
 ### Tool App
 
 You can install the tool app directly using ADB:

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/FunctionMappers.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/FunctionMappers.kt
@@ -21,7 +21,7 @@ fun List<AppFunctionMetadata>.toFunctionDeclarations(): List<FunctionDeclaration
 
 private fun AppFunctionMetadata.toFunctionDeclaration(): FunctionDeclaration = FunctionDeclaration(
     name = this.id,
-    shortName = this.schema?.name ?: "Unknown",
+    shortName = this.id.substringAfterLast("#"),
     description = this.description,
     parameters = this.toParametersSchema(),
     response = this.response.valueType.toSchema(this.components),

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
@@ -131,7 +131,7 @@ class MainViewModel(
             ),
         )
 
-        "factoryCreatedFuncA" -> mapOf("raw" to "Ping")
+        "factoryCreatedFuncA", "functionWithoutSchemaDefinition" -> mapOf("raw" to "Ping")
         else -> emptyMap()
     }
 


### PR DESCRIPTION
The function defined without `AppFunctionSchemaDefinition` was not handled.
Enable parsing and execution of this function.