### PR TITLE
refactor: Use JsonElement in GenericFunctionExecutor for type safety

### DIFF
--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/GenericFunctionExecutor.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/GenericFunctionExecutor.kt
@@ -1,18 +1,27 @@
 package dev.filipfan.appfunctionspilot.agent
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.appfunctions.AppFunctionData
 import androidx.appfunctions.AppFunctionManagerCompat
 import androidx.appfunctions.ExecuteAppFunctionRequest
 import androidx.appfunctions.ExecuteAppFunctionResponse
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 
 class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
+    companion object {
+        private const val TAG = "GenericFunctionExecutor"
+    }
 
     suspend fun executeAppFunction(
         targetPackageName: String,
         functionDeclaration: FunctionDeclaration,
-        arguments: Map<String, Any?>,
-    ): Result<Any?> = Result.runCatching {
+        arguments: Map<String, JsonElement>,
+    ): Result<JsonElement> = Result.runCatching {
         if (!manager.isAppFunctionEnabled(targetPackageName, functionDeclaration.name)) {
             throw IllegalStateException("Function (${functionDeclaration.name}) is disabled")
         }
@@ -37,15 +46,15 @@ class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
     @SuppressLint("RestrictedApi")
     private fun buildAppFunctionData(
         schema: Schema?,
-        arguments: Map<String, Any?>,
+        arguments: Map<String, JsonElement>,
     ): AppFunctionData {
         if (schema == null || schema.properties.isEmpty()) return AppFunctionData.EMPTY
 
         return AppFunctionData.Builder("").apply {
             schema.properties.forEach { (paramName, paramSchema) ->
-                val value = arguments[paramName]
-                if (value != null) {
-                    setValueOnBuilder(this, paramName, paramSchema, value)
+                val jsonValue = arguments[paramName]
+                if (jsonValue != null && jsonValue !is JsonNull) {
+                    setValueOnBuilder(this, paramName, paramSchema, jsonValue)
                 } else if (schema.required.contains(paramName) && !paramSchema.nullable) {
                     throw IllegalArgumentException("Missing required parameter: $paramName")
                 }
@@ -53,54 +62,60 @@ class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
         }.build()
     }
 
-    @Suppress("UNCHECKED_CAST")
+    private fun jsonObjectToMap(jsonObject: JsonObject): Map<String, JsonElement> = jsonObject.entrySet().associate { it.key to it.value }
+
     private fun setValueOnBuilder(
         builder: AppFunctionData.Builder,
         key: String,
         schema: Schema,
-        value: Any,
+        value: JsonElement,
     ) {
-        when (schema.type) {
-            DataType.STRING -> builder.setString(key, value as String)
-            DataType.INT -> builder.setInt(key, value as Int)
-            DataType.LONG -> builder.setLong(key, value as Long)
-            DataType.BOOLEAN -> builder.setBoolean(key, value as Boolean)
-            DataType.FLOAT -> builder.setFloat(key, value as Float)
-            DataType.DOUBLE -> builder.setDouble(key, value as Double)
-            DataType.OBJECT -> {
-                require(value is Map<*, *>) { "Value for object schema '$key' must be a Map." }
-                builder.setAppFunctionData(
-                    key,
-                    buildAppFunctionData(schema, value as Map<String, Any?>),
-                )
+        try {
+            when (schema.type) {
+                DataType.STRING -> builder.setString(key, value.asString)
+                DataType.INT -> builder.setInt(key, value.asInt)
+                DataType.LONG -> builder.setLong(key, value.asLong)
+                DataType.BOOLEAN -> builder.setBoolean(key, value.asBoolean)
+                DataType.FLOAT -> builder.setFloat(key, value.asFloat)
+                DataType.DOUBLE -> builder.setDouble(key, value.asDouble)
+                DataType.OBJECT -> {
+                    val subObjectMap = jsonObjectToMap(value.asJsonObject)
+                    builder.setAppFunctionData(
+                        key,
+                        buildAppFunctionData(schema, subObjectMap),
+                    )
+                }
+                DataType.ARRAY -> setArrayValueOnBuilder(builder, key, schema, value.asJsonArray)
+                else -> throw IllegalArgumentException("Unsupported data type: ${schema.type} for key '$key'")
             }
-
-            DataType.ARRAY -> setArrayValueOnBuilder(builder, key, schema, value as List<*>)
-            else -> throw IllegalArgumentException("Unsupported data type: ${schema.type} for key '$key'")
+        } catch (e: Exception) {
+            throw IllegalArgumentException(
+                "Failed to parse argument '$key' for type ${schema.type}. Reason: ${e.message}",
+                e,
+            )
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun setArrayValueOnBuilder(
         builder: AppFunctionData.Builder,
         key: String,
         schema: Schema,
-        value: List<*>,
+        value: JsonArray,
     ) {
         val itemsSchema = schema.items
             ?: throw IllegalStateException("Array schema for '$key' is missing 'items' definition.")
 
         when (itemsSchema.type) {
-            DataType.STRING -> builder.setStringList(key, value as List<String>)
-            DataType.INT -> builder.setIntArray(key, (value as List<Int>).toIntArray())
-            DataType.LONG -> builder.setLongArray(key, (value as List<Long>).toLongArray())
+            DataType.STRING -> builder.setStringList(key, value.map { it.asString })
+            DataType.INT -> builder.setIntArray(key, value.map { it.asInt }.toIntArray())
+            DataType.LONG -> builder.setLongArray(key, value.map { it.asLong }.toLongArray())
             DataType.OBJECT -> {
-                val objectList = (value as List<Map<String, Any?>>).map {
-                    buildAppFunctionData(itemsSchema, it)
+                val objectList = value.map {
+                    val subObjectMap = jsonObjectToMap(it.asJsonObject)
+                    buildAppFunctionData(itemsSchema, subObjectMap)
                 }
                 builder.setAppFunctionDataList(key, objectList)
             }
-
             else -> throw IllegalArgumentException("Unsupported array item type: ${itemsSchema.type} for key '$key'")
         }
     }
@@ -108,11 +123,11 @@ class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
     private fun parseSuccessResponse(
         responseSchema: Schema?,
         returnValueContainer: AppFunctionData,
-    ): Any? {
-        if (responseSchema == null || responseSchema.type == DataType.UNIT) return Unit
+    ): JsonElement {
+        if (responseSchema == null || responseSchema.type == DataType.UNIT) return JsonNull.INSTANCE
 
         val returnValueKey = ExecuteAppFunctionResponse.Success.PROPERTY_RETURN_VALUE
-        if (!returnValueContainer.containsKey(returnValueKey)) return Unit
+        if (!returnValueContainer.containsKey(returnValueKey)) return JsonNull.INSTANCE
 
         return getValueFromDataObject(returnValueContainer, returnValueKey, responseSchema)
     }
@@ -120,24 +135,36 @@ class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
     private fun convertDataObjectToMap(
         dataObject: AppFunctionData,
         schema: Schema,
-    ): Map<String, Any?> = schema.properties.mapValues { (propName, propSchema) ->
-        getValueFromDataObject(dataObject, propName, propSchema)
+    ): JsonObject = JsonObject().apply {
+        schema.properties.forEach { (propName, propSchema) ->
+            val jsonValue = getValueFromDataObject(dataObject, propName, propSchema)
+            if (!jsonValue.isJsonNull) {
+                add(propName, jsonValue)
+            } else {
+                if (propName in schema.required) {
+                    Log.w(TAG, "Property $propName $propSchema is missing in the function data")
+                }
+            }
+        }
     }
 
-    private fun getValueFromDataObject(data: AppFunctionData, key: String, schema: Schema): Any? {
-        if (!data.containsKey(key)) return null
+    private fun getValueFromDataObject(
+        data: AppFunctionData,
+        key: String,
+        schema: Schema,
+    ): JsonElement {
+        if (!data.containsKey(key)) return JsonNull.INSTANCE
 
         return when (schema.type) {
-            DataType.STRING -> data.getString(key)
-            DataType.INT -> data.getInt(key)
-            DataType.LONG -> data.getLong(key)
-            DataType.BOOLEAN -> data.getBoolean(key)
-            DataType.FLOAT -> data.getFloat(key)
-            DataType.DOUBLE -> data.getDouble(key)
+            DataType.STRING -> JsonPrimitive(data.getString(key))
+            DataType.INT -> JsonPrimitive(data.getInt(key))
+            DataType.LONG -> JsonPrimitive(data.getLong(key))
+            DataType.BOOLEAN -> JsonPrimitive(data.getBoolean(key))
+            DataType.FLOAT -> JsonPrimitive(data.getFloat(key))
+            DataType.DOUBLE -> JsonPrimitive(data.getDouble(key))
             DataType.OBJECT -> data.getAppFunctionData(key)
-                ?.let { convertDataObjectToMap(it, schema) }
-
-            DataType.ARRAY -> getArrayFromDataObject(data, key, schema)
+                ?.let { convertDataObjectToMap(it, schema) } ?: JsonNull.INSTANCE
+            DataType.ARRAY -> getArrayFromDataObject(data, key, schema) ?: JsonNull.INSTANCE
             else -> throw IllegalArgumentException("Unsupported item type for parsing: ${schema.type}")
         }
     }
@@ -146,19 +173,22 @@ class GenericFunctionExecutor(private val manager: AppFunctionManagerCompat) {
         data: AppFunctionData,
         key: String,
         schema: Schema,
-    ): List<*>? {
+    ): JsonArray? {
         val itemsSchema = schema.items
             ?: throw IllegalStateException("Array schema for '$key' is missing 'items' definition.")
 
-        return when (itemsSchema.type) {
-            DataType.STRING -> data.getStringList(key)
-            DataType.INT -> data.getIntArray(key)?.toList()
-            DataType.LONG -> data.getLongArray(key)?.toList()
+        val elements: List<JsonElement>? = when (itemsSchema.type) {
+            DataType.STRING -> data.getStringList(key)?.map { JsonPrimitive(it) }
+            DataType.INT -> data.getIntArray(key)?.map { JsonPrimitive(it) }
+            DataType.LONG -> data.getLongArray(key)?.map { JsonPrimitive(it) }
             DataType.OBJECT -> data.getAppFunctionDataList(key)?.map {
                 convertDataObjectToMap(it, itemsSchema)
             }
-
             else -> throw IllegalArgumentException("Unsupported array item type for parsing: ${itemsSchema.type}")
+        }
+
+        return elements?.let { list ->
+            JsonArray().apply { list.forEach(::add) }
         }
     }
 }

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
@@ -116,8 +116,8 @@ class MainViewModel(
         "argumentOptionalValues" -> mapOf(
             "v" to mapOf(
                 "optionalNullableInt" to 123,
-                "optionalNullableLong" to null,
-                "optionalNullableString" to "test",
+                "optionalNullableLong" to 9,
+                "optionalNullableString" to null,
             ),
         )
 
@@ -138,7 +138,7 @@ class MainViewModel(
     fun executeAppFunction(function: FunctionDeclaration) {
         // Test arguments for demonstration.
         Log.i(TAG, "Function invoked: ${function.toJsonString()}")
-        val arguments = getTestArgumentsForFunction(function.shortName)
+        val arguments = getTestArgumentsForFunction(function.shortName).mapValues { gson.toJsonTree(it.value) }
         viewModelScope.launch {
             val result =
                 functionExecutor.executeAppFunction(


### PR DESCRIPTION
The `executeAppFunction` method has been updated to accept `Map<String, JsonElement>` as arguments and return `Result<JsonElement>`.

This change enforces a stricter, JSON-based contract between the caller and the executor. It improves type safety by ensuring all data passed to the function executor is already in a structured JSON format, preventing potential runtime type errors.