### PR TITLE
chore: bump appfunctions to version 1.0.0-alpha05

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeCompose = "2.8.3"
 spotless = "7.1.0"
 kotlinxCoroutinesGuava = "1.10.2"
 gson = "2.10.1"
-appfunctions = "1.0.0-alpha04"
+appfunctions = "1.0.0-alpha05"
 ksp = "2.1.21-2.0.1"
 
 [libraries]


### PR DESCRIPTION
No update on code.
Upgrade to use the latest verion 1.0.0-alpha05 for
- appfunctions
- appfunctions-service
- appfunctions-compiler