### PR TITLE
feat(agent): Adapt implementation for AppFunctions 1.0.0-alpha06

### DIFF
--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/FunctionMappers.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/FunctionMappers.kt
@@ -15,9 +15,7 @@ import androidx.appfunctions.metadata.AppFunctionReferenceTypeMetadata
 import androidx.appfunctions.metadata.AppFunctionStringTypeMetadata
 import androidx.appfunctions.metadata.AppFunctionUnitTypeMetadata
 
-fun List<AppFunctionMetadata>.toFunctionDeclarations(): List<FunctionDeclaration> = this.map {
-    it.toFunctionDeclaration()
-}
+fun List<AppFunctionMetadata>.toFunctionDeclarations(): Map<FunctionDeclaration, AppFunctionMetadata> = this.associateBy { it.toFunctionDeclaration() }
 
 private fun AppFunctionMetadata.toFunctionDeclaration(): FunctionDeclaration = FunctionDeclaration(
     name = this.id,

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainActivity.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background,
                 ) {
                     MainScreen(
-                        functionItems = functionItems,
+                        functionItems = functionItems.toList(),
                         onFunctionClick = { item ->
                             Log.i(TAG, "Function calling: $item")
                             viewModel.executeAppFunction(item)

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/MainViewModel.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import androidx.appfunctions.AppFunctionManagerCompat
 import androidx.appfunctions.AppFunctionSearchSpec
 import androidx.appfunctions.metadata.AppFunctionDataTypeMetadata
+import androidx.appfunctions.metadata.AppFunctionMetadata
 import androidx.appfunctions.metadata.AppFunctionPackageMetadata
 import androidx.core.net.toUri
 import androidx.lifecycle.AndroidViewModel
@@ -23,10 +24,13 @@ import com.google.gson.JsonSerializer
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.lang.reflect.Type
@@ -68,9 +72,14 @@ class MainViewModel(
             }
         }
 
-    private val _functionDeclarations = MutableStateFlow<List<FunctionDeclaration>>(emptyList())
-    val functionDeclarations: StateFlow<List<FunctionDeclaration>> =
-        _functionDeclarations.asStateFlow()
+    private val functionMetadataMap =
+        MutableStateFlow<Map<FunctionDeclaration, AppFunctionMetadata>>(emptyMap())
+    val functionDeclarations: StateFlow<Set<FunctionDeclaration>> =
+        functionMetadataMap.map { map -> map.keys }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000L),
+            initialValue = emptySet(),
+        )
 
     private val _functionResponse = MutableStateFlow("Latest function calling response")
     val functionResponse = _functionResponse.asStateFlow()
@@ -105,7 +114,7 @@ class MainViewModel(
                     processPackageMetadata(metadata)
                 } ?: run {
                     Log.w(TAG, "Unable to find functions for the target package '$TARGET_PACKAGE'")
-                    _functionDeclarations.value = emptyList()
+                    functionMetadataMap.value = emptyMap()
                 }
             }
             .launchIn(viewModelScope)
@@ -123,6 +132,25 @@ class MainViewModel(
 
         "add" -> mapOf("num1" to 10L, "num2" to 6L)
         "getProductDetails" -> mapOf("productId" to "p001")
+        "processProducts" -> mapOf(
+            "products" to listOf(
+                mapOf(
+                    "sku" to "SKU1001",
+                    "stockQuantity" to 50,
+                    "isActive" to true,
+                ),
+                mapOf(
+                    "sku" to "SKU1002",
+                    "stockQuantity" to 0,
+                    "isActive" to false,
+                ),
+                mapOf(
+                    "sku" to "SKU1003",
+                    "stockQuantity" to 120,
+                    "isActive" to true,
+                ),
+            ),
+        )
         "getWeather" -> mapOf(
             "param" to mapOf(
                 "location" to "Tokyo",
@@ -136,13 +164,17 @@ class MainViewModel(
     }
 
     fun executeAppFunction(function: FunctionDeclaration) {
+        val metadata = functionMetadataMap.value[function]
+            ?: throw IllegalStateException("Failed to find AppFunctionMetadata for ${function.shortName}")
         // Test arguments for demonstration.
         Log.i(TAG, "Function invoked: ${function.toJsonString()}")
-        val arguments = getTestArgumentsForFunction(function.shortName).mapValues { gson.toJsonTree(it.value) }
+        val arguments =
+            getTestArgumentsForFunction(function.shortName).mapValues { gson.toJsonTree(it.value) }
         viewModelScope.launch {
             val result =
                 functionExecutor.executeAppFunction(
                     targetPackageName = TARGET_PACKAGE,
+                    appFunctionMetadata = metadata,
                     functionDeclaration = function,
                     arguments = arguments,
                 )
@@ -168,7 +200,7 @@ class MainViewModel(
 
             if (metadataJson.isNullOrBlank()) {
                 Log.w(TAG, "Metadata JSON is null or empty.")
-                _functionDeclarations.value = emptyList()
+                functionMetadataMap.value = emptyMap()
                 return
             }
 
@@ -181,16 +213,16 @@ class MainViewModel(
                 processPackageMetadata(metadata)
             } ?: run {
                 Log.w(TAG, "Unable to find functions via the content provider.")
-                _functionDeclarations.value = emptyList()
+                functionMetadataMap.value = emptyMap()
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to call ToolProvider", e)
-            _functionDeclarations.value = emptyList()
+            functionMetadataMap.value = emptyMap()
         }
     }
 
     private fun processPackageMetadata(metadata: AppFunctionPackageMetadata) {
-        _functionDeclarations.value = metadata.appFunctions.toFunctionDeclarations()
+        functionMetadataMap.value = metadata.appFunctions.toFunctionDeclarations()
 
         viewModelScope.launch {
             val appMetadata = withContext(Dispatchers.IO) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeCompose = "2.8.3"
 spotless = "7.1.0"
 kotlinxCoroutinesGuava = "1.10.2"
 gson = "2.10.1"
-appfunctions = "1.0.0-alpha05"
+appfunctions = "1.0.0-alpha06"
 ksp = "2.1.21-2.0.1"
 
 [libraries]

--- a/tool/src/main/java/dev/filipfan/appfunctionspilot/tool/functions/SampleFunctions.kt
+++ b/tool/src/main/java/dev/filipfan/appfunctionspilot/tool/functions/SampleFunctions.kt
@@ -136,6 +136,26 @@ class GetProductDetailsImpl : GetProductDetails {
     }
 }
 
+class ProcessProductsImpl : ProcessProducts {
+    /**
+     * Processes a list of products.
+     *
+     * @param products A list of ProductInfo objects to be processed.
+     * @return A Boolean indicating whether the processing was considered successful.
+     * For this example, it simply returns true if the product list was not empty.
+     */
+    @AppFunction(isDescribedByKdoc = true)
+    override fun processProducts(
+        appFunctionContext: AppFunctionContext,
+        products: List<ProcessProducts.ProductInfo>,
+    ): Boolean {
+        Log.i(TAG, "processProducts called with ${products.size} products.")
+
+        val success = products.isNotEmpty()
+        return success
+    }
+}
+
 class GetLocalDateImpl : GetLocalDate {
     /**
      * Retrieves the current local date and time.

--- a/tool/src/main/java/dev/filipfan/appfunctionspilot/tool/functions/SampleFunctionsSchemas.kt
+++ b/tool/src/main/java/dev/filipfan/appfunctionspilot/tool/functions/SampleFunctionsSchemas.kt
@@ -58,6 +58,24 @@ interface GetProductDetails {
     fun getProductDetails(appFunctionContext: AppFunctionContext, productId: String): String
 }
 
+@AppFunctionSchemaDefinition(name = "processProducts", version = 1, category = "sampleTool")
+interface ProcessProducts {
+    /**
+     * A data class representing product information.
+     */
+    @AppFunctionSerializable(isDescribedByKdoc = true)
+    data class ProductInfo(
+        /** The unique SKU (Stock Keeping Unit) for the product. */
+        val sku: String,
+        /** The number of items in stock. */
+        val stockQuantity: Int,
+        /** Whether the product is currently active. */
+        val isActive: Boolean,
+    )
+
+    fun processProducts(appFunctionContext: AppFunctionContext, products: List<ProductInfo>): Boolean
+}
+
 @AppFunctionSchemaDefinition(name = "getLocalDate", version = 1, category = "sampleTool")
 interface GetLocalDate {
     /**


### PR DESCRIPTION
As part of the migration to `appfunctions-1.0.0-alpha06`, the `AppFunctionData.Builder` API now only provides validated constructiors.

This commit refactors `GenericFunctionExecutor` to align with this new SDK, which is necessary to serialize arguments and deserialize results correctly.

Key changes:
- `executeAppFunction` signature is updated to accept `AppFunctionMetadata`, which is now required for building the request.

Upstream references:
- https://android-review.googlesource.com/c/platform/frameworks/support/+/3775347