### PR TITLE
chore: update the appfunctions libraries to 1.0.0-alpha07

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeCompose = "2.8.3"
 spotless = "7.1.0"
 kotlinxCoroutinesGuava = "1.10.2"
 gson = "2.10.1"
-appfunctions = "1.0.0-alpha06"
+appfunctions = "1.0.0-alpha07"
 ksp = "2.1.21-2.0.1"
 
 [libraries]


### PR DESCRIPTION
Update the dependency to `appfunctions:1.0.0-alpha07`. This update contains a good fix for non-null required top-level parameters in tool side.
In our case, this solves `functionNullable` exception when the parameter is null.

Reference:
https://android-review.googlesource.com/c/platform/frameworks/support/+/3830955