### PR TITLE
doc: fix broken link to ai edge apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ adb reboot
 
 - [Android Jetpack Source](https://android.googlesource.com/platform/frameworks/support/)
 - [AppFunctionManager API reference](https://developer.android.com/reference/android/app/appfunctions/AppFunctionManager)
-- [ai-edge-apis](https://github.com/google-ai-edge/ai-edge-apis)
+- [ai-edge-apis](https://ai.google.dev/edge/mediapipe/solutions/genai/function_calling)
 - [exploring-appfunctions](https://github.com/jamiesanson/exploring-appfunctions)


### PR DESCRIPTION
The ai-edge-apis is deprecated.
The GitHub repository of ai-edge-apis is no longer publicly available. Update to point to the developer site.