### PR TITLE
feat: support non-root agent launching via instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,35 +40,50 @@ The agent app requires the `android.permission.EXECUTE_APP_FUNCTIONS` permission
 
 Before installation, check the protection level of this permission on your test device or emulator:
 
-```
+```bash
 adb shell pm list permissions -f | grep -A 5 "EXECUTE_APP_FUNCTIONS"
 ```
 
 - **If the level is `normal`:** You can install the app directly via `adb install agent-debug.apk`.
+- **If the level is `privileged`:** Choose one of the following two options to grant the permission.
 
-- **If the level is `privileged`:** You must follow the root-access installation steps below.
+2. **Granting Privileged Permission**
 
-2. **Privileged Installation** 
+#### Option A: Using Instrumentation
 
-If the permission level is privileged, follow these steps to install the app as a system-privileged package. This process requires a rooted device or emulator with remount capabilities.
+This method uses Android's Instrumentation mechanism to bypass permission restriction. It **does not require root access**.
 
-**Step A: Disable Permission Enforcement** Modify the `build.prop` file to disable privileged permission enforcement.
+1. Install the Agent app normally:
+   ```bash
+   adb install agent-debug.apk
+   ```
+2. Launch the app using the provided script:
+   ```bash
+   ./start_agent.sh
+   ```
+> [!IMPORTANT]
+> You must use this script to launch the app. Opening it from the launcher icon will not grant the required privileged permissions.
 
-```
+#### Option B: Privileged Installation
+
+This method installs the app as a system-privileged package. It requires a **rooted device** or emulator with remount capabilities.
+
+**Step 1: Disable Permission Enforcement**
+Modify the `build.prop` file to disable privileged permission enforcement:
+```bash
 adb root
 adb remount
 adb shell "sed -i 's/ro.control_privapp_permissions=enforce/ro.control_privapp_permissions=log/g' /vendor/build.prop"
 ```
 
-**Step B: Install as a Privileged App** Push the APK to the privileged apps directory, such as `/system/priv-app`:
-
-```
+**Step 2: Install as a Privileged App**
+Push the APK to the privileged apps directory:
+```bash
 adb push agent-debug.apk /system/priv-app
 adb reboot
 ```
 
 > [!NOTE]
->
 > After the initial privileged installation, you can update the agent app using a standard `adb install` command, provided its permissions in the manifest do not change.
 
 ## References
@@ -77,3 +92,4 @@ adb reboot
 - [AppFunctionManager API reference](https://developer.android.com/reference/android/app/appfunctions/AppFunctionManager)
 - [ai-edge-apis](https://ai.google.dev/edge/mediapipe/solutions/genai/function_calling)
 - [exploring-appfunctions](https://github.com/jamiesanson/exploring-appfunctions)
+- [AppFunctions Testing Agent](https://github.com/android/appfunctions/releases/tag/initial)

--- a/agent/src/main/AndroidManifest.xml
+++ b/agent/src/main/AndroidManifest.xml
@@ -10,6 +10,12 @@
         <package android:name="dev.filipfan.appfunctionspilot.tool" />
     </queries>
 
+    <!-- A handy trick to bypass permission restrictions via the shell during development. -->
+    <instrumentation
+        android:name=".ShellIdentityInstrumentation"
+        android:targetPackage="dev.filipfan.appfunctionspilot.agent"
+        android:label="Agent Shell Identity Instrumentation" />
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/ShellIdentityInstrumentation.kt
+++ b/agent/src/main/java/dev/filipfan/appfunctionspilot/agent/ShellIdentityInstrumentation.kt
@@ -1,0 +1,48 @@
+package dev.filipfan.appfunctionspilot.agent
+
+import android.app.Instrumentation
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import java.util.concurrent.CountDownLatch
+
+/**
+ * An [Instrumentation] that adopts shell permissions and starts the [MainActivity].
+ *
+ * This allows the app to acquire privileged permissions like EXECUTE_APP_FUNCTIONS
+ * when started via `adb shell am instrument`.
+ */
+class ShellIdentityInstrumentation : Instrumentation() {
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+        // Start the instrumentation thread
+        start()
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        // Adopt shell permissions to acquire privileged permissions
+        uiAutomation.adoptShellPermissionIdentity(
+            "android.permission.EXECUTE_APP_FUNCTIONS",
+        )
+
+        // Start the MainActivity
+        val intent = Intent.makeMainActivity(
+            ComponentName(
+                targetContext,
+                MainActivity::class.java,
+            ),
+        )
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        targetContext.startActivity(intent)
+
+        // Keep the instrumentation process alive to maintain the adopted permissions
+        try {
+            CountDownLatch(1).await()
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}

--- a/start_agent.sh
+++ b/start_agent.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# This script launches the Agent app using Instrumentation
+# to acquire privileged permissions via Shell identity.
+# Package and instrumentation details
+PACKAGE_NAME="dev.filipfan.appfunctionspilot.agent"
+INSTRUMENTATION_NAME="${PACKAGE_NAME}/.ShellIdentityInstrumentation"
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help     Show this help message"
+    echo ""
+    echo "Description:"
+    echo "  Launches the Agent app with EXECUTE_APP_FUNCTIONS permission"
+    echo "  using ShellIdentityInstrumentation."
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown parameter: $1"; usage; exit 1 ;;
+    esac
+    shift
+done
+
+echo "🔍 Verifying Agent app installation..."
+if ! adb shell pm list packages | grep -q "$PACKAGE_NAME"; then
+    echo "❌ Package $PACKAGE_NAME is not installed."
+    echo "Please install the Agent app first."
+    exit 1
+fi
+
+echo "🛑 Stopping any existing Agent instances..."
+adb shell am force-stop "$PACKAGE_NAME"
+
+echo "🚀 Starting Agent via ShellIdentityInstrumentation..."
+adb shell am instrument -w "$INSTRUMENTATION_NAME"


### PR DESCRIPTION
This change introduces a way to launch the Agent app with the required privileged permission "EXECUTE_APP_FUNCTIONS" without needing a rooted device.

- Add ShellIdentityInstrumentation to adopt shell permissions.
- Register instrumentation in the Agent's AndroidManifest.xml.
- Provide start_agent.sh for a streamlined, non-root launch process.
- Update README.md to document this as the recommended dev approach.